### PR TITLE
Refactor portainer web login

### DIFF
--- a/src/components/stack-stats/PortainerLogin.tsx
+++ b/src/components/stack-stats/PortainerLogin.tsx
@@ -1,17 +1,13 @@
 import React from "react";
 import { useLoggedAppContext } from "../AppContext";
 
-interface PortainerLoginProps {
-    onLogin: () => void;
-}
-
-export const PortainerLogin: React.FC<PortainerLoginProps> = React.memo(props => {
-    const { onLogin } = props;
+export const PortainerLogin: React.FC<{}> = React.memo(props => {
     const iframeRef = React.useRef<HTMLIFrameElement>(null);
     const { compositionRoot, userSession: currentUser } = useLoggedAppContext();
     const portainerUrl = React.useMemo(() => compositionRoot.dataSource.info().url, [
         compositionRoot,
     ]);
+    const [isLoggedIn, setLoggedIn] = React.useState(false);
 
     const login = React.useCallback(async () => {
         const iframe = iframeRef.current;
@@ -34,19 +30,23 @@ export const PortainerLogin: React.FC<PortainerLoginProps> = React.memo(props =>
                 localStorage["portainer.ENDPOINT_ID"] = JSON.stringify(currentUser.endpointId);
             }
 
-            onLogin();
+            setLoggedIn(true);
         }
-    }, [currentUser, onLogin]);
+    }, [currentUser, setLoggedIn]);
 
-    return (
-        <iframe
-            style={{ display: "none" }}
-            ref={iframeRef}
-            title="Portainer login"
-            src={portainerUrl}
-            width="100%"
-            height="800"
-            onLoad={login}
-        />
-    );
+    if (isLoggedIn) {
+        return <React.Fragment>{props.children}</React.Fragment>;
+    } else {
+        return (
+            <iframe
+                style={{ display: "none" }}
+                ref={iframeRef}
+                title="Portainer login"
+                src={portainerUrl}
+                width="100%"
+                height="800"
+                onLoad={login}
+            />
+        );
+    }
 });

--- a/src/components/stack-stats/PortainerLogin.tsx
+++ b/src/components/stack-stats/PortainerLogin.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { useLoggedAppContext } from "../AppContext";
+
+interface PortainerLoginProps {
+    onLogin: () => void;
+}
+
+export const PortainerLogin: React.FC<PortainerLoginProps> = React.memo(props => {
+    const { onLogin } = props;
+    const iframeRef = React.useRef<HTMLIFrameElement>(null);
+    const { compositionRoot, userSession: currentUser } = useLoggedAppContext();
+    const portainerUrl = React.useMemo(() => compositionRoot.dataSource.info().url, [
+        compositionRoot,
+    ]);
+
+    const login = React.useCallback(async () => {
+        const iframe = iframeRef.current;
+        const idocument = iframe?.contentWindow?.document;
+        if (!iframe || !iframe.contentWindow || !idocument) return;
+        const sideview = idocument.querySelector("#sideview");
+
+        if (!sideview) {
+            setTimeout(login, 1000);
+        } else {
+            const isLoginPage = !!idocument.querySelector(
+                '[ng-show="!ctrl.state.loginInProgress"]'
+            );
+            console.debug("isLoginPage", isLoginPage);
+
+            if (isLoginPage) {
+                const { localStorage } = iframe.contentWindow;
+                console.debug("Set portainer session variables");
+                localStorage["portainer.JWT"] = JSON.stringify(currentUser.token);
+                localStorage["portainer.ENDPOINT_ID"] = JSON.stringify(currentUser.endpointId);
+            }
+
+            onLogin();
+        }
+    }, [currentUser, onLogin]);
+
+    return (
+        <iframe
+            style={{ display: "none" }}
+            ref={iframeRef}
+            title="Portainer login"
+            src={portainerUrl}
+            width="100%"
+            height="800"
+            onLoad={login}
+        />
+    );
+});

--- a/src/components/stack-stats/StackStats.tsx
+++ b/src/components/stack-stats/StackStats.tsx
@@ -19,7 +19,6 @@ export const StackStats: React.FC<StackStatsProps> = React.memo(props => {
     const title = i18n.t("Stats: ") + stack.dataImage;
     const stats = compositionRoot.stacks.getStats(stack);
     const contentsRef = React.useRef<HTMLDivElement | null>(null);
-    const [isPortainerLoggedIn, setPortainerLoggedIn] = React.useState(false);
 
     return (
         <ConfirmationDialog
@@ -30,15 +29,13 @@ export const StackStats: React.FC<StackStatsProps> = React.memo(props => {
             fullWidth={true}
             maxWidth="xl"
         >
-            {isPortainerLoggedIn ? (
+            <PortainerLogin>
                 <div className={classes.root} ref={contentsRef}>
                     <StatsDetails title={i18n.t("Core")} url={stats.core} />
                     <StatsDetails title={i18n.t("Database")} url={stats.db} />
                     <StatsDetails title={i18n.t("Nginx")} url={stats.gateway} />
                 </div>
-            ) : (
-                <PortainerLogin onLogin={() => setPortainerLoggedIn(true)} />
-            )}
+            </PortainerLogin>
         </ConfirmationDialog>
     );
 });

--- a/src/components/stack-stats/StackStats.tsx
+++ b/src/components/stack-stats/StackStats.tsx
@@ -5,6 +5,7 @@ import { D2Stack } from "../../domain/entities/D2Stack";
 import { useLoggedAppContext } from "../AppContext";
 import { makeStyles } from "@material-ui/core";
 import { StatsDetails } from "./StatsDetails";
+import { PortainerLogin } from "./PortainerLogin";
 
 interface StackStatsProps {
     stack: D2Stack;
@@ -18,6 +19,7 @@ export const StackStats: React.FC<StackStatsProps> = React.memo(props => {
     const title = i18n.t("Stats: ") + stack.dataImage;
     const stats = compositionRoot.stacks.getStats(stack);
     const contentsRef = React.useRef<HTMLDivElement | null>(null);
+    const [isPortainerLoggedIn, setPortainerLoggedIn] = React.useState(false);
 
     return (
         <ConfirmationDialog
@@ -28,11 +30,15 @@ export const StackStats: React.FC<StackStatsProps> = React.memo(props => {
             fullWidth={true}
             maxWidth="xl"
         >
-            <div className={classes.root} ref={contentsRef}>
-                <StatsDetails title={i18n.t("Core")} url={stats.core} />
-                <StatsDetails title={i18n.t("Database")} url={stats.db} />
-                <StatsDetails title={i18n.t("Nginx")} url={stats.gateway} />
-            </div>
+            {isPortainerLoggedIn ? (
+                <div className={classes.root} ref={contentsRef}>
+                    <StatsDetails title={i18n.t("Core")} url={stats.core} />
+                    <StatsDetails title={i18n.t("Database")} url={stats.db} />
+                    <StatsDetails title={i18n.t("Nginx")} url={stats.gateway} />
+                </div>
+            ) : (
+                <PortainerLogin onLogin={() => setPortainerLoggedIn(true)} />
+            )}
         </ConfirmationDialog>
     );
 });

--- a/src/components/stack-stats/StatsDetails.tsx
+++ b/src/components/stack-stats/StatsDetails.tsx
@@ -7,7 +7,6 @@ import {
     makeStyles,
 } from "@material-ui/core";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
-import { useLoggedAppContext } from "../AppContext";
 
 interface StatsDetailsProps {
     title: string;
@@ -18,38 +17,22 @@ interface StatsDetailsProps {
 export const StatsDetails: React.FC<StatsDetailsProps> = React.memo(props => {
     const { title, url, initialOpen } = props;
     const classes = useStyles();
-    const { userSession: currentUser } = useLoggedAppContext();
     const iframeRef = React.useRef<HTMLIFrameElement>(null);
 
-    const login = React.useCallback(() => {
-        const iframe = iframeRef.current;
-        const idocument = iframe?.contentWindow?.document;
-        if (!iframe || !iframe.contentWindow || !idocument) return;
-        const sideview = idocument.querySelector("#sideview");
+    const cleanPage = React.useCallback(() => {
+        const idocument = iframeRef.current?.contentWindow?.document;
 
-        if (!sideview) {
-            setTimeout(login, 1000);
+        if (!idocument) {
+            return;
+        } else if (!idocument.querySelector(".row.header")) {
+            setTimeout(cleanPage, 1000);
         } else {
-            const isLoginPage = !!idocument.querySelector(
-                '[ng-show="!ctrl.state.loginInProgress"]'
-            );
-            if (isLoginPage) {
-                const { localStorage } = iframe.contentWindow;
-                localStorage["portainer.JWT"] = JSON.stringify(currentUser.token);
-                localStorage["portainer.ENDPOINT_ID"] = JSON.stringify(currentUser.endpointId);
-                const location = iframe.contentWindow.location;
-                setTimeout(() => {
-                    location.replace(url + "#" + new Date().getTime());
-                    login();
-                }, 1000);
-            } else {
-                on(idocument, "#sideview", el => remove(el));
-                on(idocument, "#page-wrapper", el => (el.style.paddingLeft = "0px"));
-                on(idocument, ".row.ng-scope", el => remove(el));
-                onAll(idocument, ".row.header", el => remove(el));
-            }
+            on(idocument, "#sideview", el => hide(el));
+            on(idocument, "#page-wrapper", el => (el.style.paddingLeft = "0px"));
+            on(idocument, ".row.ng-scope", el => hide(el));
+            onAll(idocument, ".row.header", el => hide(el));
         }
-    }, [currentUser, url]);
+    }, []);
 
     return (
         <ExpansionPanel className={classes.panel} defaultExpanded={initialOpen}>
@@ -67,7 +50,7 @@ export const StatsDetails: React.FC<StatsDetailsProps> = React.memo(props => {
                     frameBorder="0"
                     marginHeight={0}
                     marginWidth={0}
-                    onLoad={login}
+                    onLoad={cleanPage}
                 />
             </ExpansionPanelDetails>
         </ExpansionPanel>
@@ -84,7 +67,7 @@ const useStyles = makeStyles(theme => ({
     },
 }));
 
-function remove<T extends HTMLElement>(element: T): void {
+function hide<T extends HTMLElement>(element: T): void {
     element.style.display = "none";
 }
 
@@ -93,11 +76,7 @@ function on(document: Document, selector: string, action: (el: HTMLElement) => v
     if (element) action(element);
 }
 
-function onAll<T extends Element>(
-    document: Document,
-    selector: string,
-    action: (el: HTMLElement) => void
-): void {
+function onAll(document: Document, selector: string, action: (el: HTMLElement) => void): void {
     const elements = document.querySelectorAll<HTMLElement>(selector);
     Array.from(elements).forEach(el => action(el));
 }

--- a/src/components/stack-stats/StatsDetails.tsx
+++ b/src/components/stack-stats/StatsDetails.tsx
@@ -25,8 +25,10 @@ export const StatsDetails: React.FC<StatsDetailsProps> = React.memo(props => {
         if (!idocument) {
             return;
         } else if (!idocument.querySelector(".row.header")) {
+            console.debug("Wait for page");
             setTimeout(cleanPage, 1000);
         } else {
+            console.debug("Clean page");
             on(idocument, "#sideview", el => hide(el));
             on(idocument, "#page-wrapper", el => (el.style.paddingLeft = "0px"));
             on(idocument, ".row.ng-scope", el => hide(el));

--- a/src/data/D2StacksPortainerRepository.ts
+++ b/src/data/D2StacksPortainerRepository.ts
@@ -95,7 +95,7 @@ export class D2StacksPortainerRepository implements D2StacksRepository {
     }
 
     getStatsUrls(stack: D2Stack): D2StackStats {
-        const baseUrl = this.api.baseUrl;
+        const baseUrl = this.api.baseUrl.replace(/\/*$/, "");
         return _.mapValues(
             stack.containers,
             container => `${baseUrl}/#/containers/${container.id}/stats`


### PR DESCRIPTION
Closes #17 

Instead of making independent logins on each stat iframe, now the component wrapper `PortainerLogin.tsx` makes a single login.